### PR TITLE
task: Add more config options

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ADD wsgi.py wsgi.py
 ADD Pipfile Pipfile
 ADD Pipfile.lock Pipfile.lock
 RUN pip install pipenv && pipenv install --system && pipenv install --dev --system
+ADD health_audit_runner.py health_audit_runner.py
 ADD cmd.sh cmd.sh
 RUN chmod +x cmd.sh
 ENTRYPOINT [ "/data-trust-logger/cmd.sh" ]

--- a/cmd.sh
+++ b/cmd.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
-
 if [ "$APP_ENV" == "LOCAL" ] || [ -z "$APP_ENV" ]; then
     python health_audit_runner.py &
     HEALTH_AUDIT_PID=$!
-    gunicorn -w 4 -b 0.0.0.0:8002 wsgi:app --reload --worker-class gevent
+    gunicorn -w 4 -b 0.0.0.0:8002 wsgi:app --reload --worker-class gevent --timeout 120
     trap "kill -9 $HEALTH_AUDIT_PID" EXIT
 else
-    MAX_RETRIES=5
     WORKERS=4
-    RETRIES=0
-    gunicorn -b 0.0.0.0 -w $WORKERS wsgi:app --worker-class gevent
+    MODE=$@
+    if [ "$MODE" == "--health-audit" ]; then
+        python health_audit_runner.py
+    else
+        gunicorn -b 0.0.0.0 -w $WORKERS wsgi:app --worker-class gevent
+    fi
 fi

--- a/cmd.sh
+++ b/cmd.sh
@@ -6,10 +6,6 @@ if [ "$APP_ENV" == "LOCAL" ] || [ -z "$APP_ENV" ]; then
     trap "kill -9 $HEALTH_AUDIT_PID" EXIT
 else
     WORKERS=4
-    MODE=$@
-    if [ "$MODE" == "--health-audit" ]; then
-        python health_audit_runner.py
-    else
-        gunicorn -b 0.0.0.0 -w $WORKERS wsgi:app --worker-class gevent
-    fi
+    python health_audit_runner.py &
+    gunicorn -b 0.0.0.0 -w $WORKERS wsgi:app --worker-class gevent
 fi

--- a/cmd.sh
+++ b/cmd.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ "$APP_ENV" == "DEVELOPMENT" ] || [ -z "$APP_ENV" ]; then
+if [ "$APP_ENV" == "LOCAL" ] || [ -z "$APP_ENV" ]; then
     python health_audit_runner.py &
     HEALTH_AUDIT_PID=$!
     gunicorn -w 4 -b 0.0.0.0:8002 wsgi:app --reload --worker-class gevent

--- a/data_trust_logger/config/config.example.json
+++ b/data_trust_logger/config/config.example.json
@@ -1,5 +1,5 @@
 {
-    "development": {
+    "local_testing": {
         "data_resources": {
             "dr_url": "http://0.0.0.0:8001",
             "dr_psql_user": "test_user",
@@ -22,5 +22,7 @@
             "audience": "http://localhost:8000",
             "oauth2_url": "https://<url_to_authserver>/oauth/token"
         }
-    }
+    },
+    "development_testing": { },
+    "production": {}
 }

--- a/data_trust_logger/config/config.example.json
+++ b/data_trust_logger/config/config.example.json
@@ -1,5 +1,5 @@
 {
-    "local_testing": {
+    "local": {
         "data_resources": {
             "dr_url": "http://0.0.0.0:8001",
             "dr_psql_user": "test_user",

--- a/data_trust_logger/config/config.py
+++ b/data_trust_logger/config/config.py
@@ -106,8 +106,14 @@ class Configuration(object):
             raise ConfigurationError(
                 'Cannot find environment \'{}\' in JSON configuration.')
 
+class LocalConfiguration(Configuration):
+    """Development configuration class."""
+    def __init__(self):
+        self.from_json()
+        self.debug = True
+        self.testing = True
 
-class DevelopmentConfiguration(Configuration):
+class DevelopmentTestingConfiguration(Configuration):
     """Development configuration class."""
 
     def __init__(self):
@@ -115,12 +121,23 @@ class DevelopmentConfiguration(Configuration):
         self.debug = True
         self.testing = False
 
+class ProductionConfiguration(Configuration):
+    """Production configuratuon class."""
+
+    def __init__(self):
+        self.from_env()
+        self.debug = False
+        self.testing = False
 
 class ConfigurationFactory(object):
     @staticmethod
     def get_config(config_type: str):
-        if config_type.upper() == 'DEVELOPMENT':
-            return DevelopmentConfiguration()
+        if config_type.upper() == 'LOCAL':
+            return LocalConfiguration()
+        if config_type.upper() == 'DEVELOPMENT_TESTING':
+            return DevelopmentTestingConfiguration()
+        if config_type.upper() == 'PRODUCTION':
+            return ProductionConfiguration()
 
     @staticmethod
     def from_env():
@@ -130,6 +147,6 @@ class ConfigurationFactory(object):
         Returns:
             object: Configuration object based on the configuration environment found in the `APP_ENV` environment variable.
         """
-        environment = os.getenv('APP_ENV', 'DEVELOPMENT')
+        environment = os.getenv('APP_ENV', 'LOCAL')
 
         return ConfigurationFactory.get_config(environment)

--- a/data_trust_logger/config/config.py
+++ b/data_trust_logger/config/config.py
@@ -47,7 +47,7 @@ class Configuration(object):
             raise ConfigurationError(
                 'Failed to load configuration file {}. Please check the configuration file.'.format(config_file))
 
-    def from_json(self, environment='development'):
+    def from_json(self, environment='local'):
         """Load application configuration from JSON object based on the configuration type.
         Args:
             environment (str): The environment to load.
@@ -57,6 +57,7 @@ class Configuration(object):
 
         config_file = self.find_json_config_file()
         data = self.load_json_config(config_file)
+
         if environment in data.keys():
             fields = data[environment]
             try:
@@ -107,14 +108,14 @@ class Configuration(object):
                 'Cannot find environment \'{}\' in JSON configuration.')
 
 class LocalConfiguration(Configuration):
-    """Development configuration class."""
+    """Configuration class for local development."""
     def __init__(self):
         self.from_json()
         self.debug = True
         self.testing = True
 
 class DevelopmentTestingConfiguration(Configuration):
-    """Development configuration class."""
+    """Configuration class for deployment of app on the Dev Testing server."""
 
     def __init__(self):
         self.from_json()
@@ -122,7 +123,7 @@ class DevelopmentTestingConfiguration(Configuration):
         self.testing = False
 
 class ProductionConfiguration(Configuration):
-    """Production configuratuon class."""
+    """Configuratuon class for production deployment."""
 
     def __init__(self):
         self.from_env()
@@ -142,7 +143,7 @@ class ConfigurationFactory(object):
     @staticmethod
     def from_env():
         """Retrieve configuration based on environment settings.
-        Provides a configuration object based on the settings found in the `APP_ENV` variable. Defaults to the `development`
+        Provides a configuration object based on the settings found in the `APP_ENV` variable. Defaults to the `local`
         environment if the variable is not set.
         Returns:
             object: Configuration object based on the configuration environment found in the `APP_ENV` environment variable.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,13 @@ version: '3'
 services: 
     data-trust-logger: 
       image: brighthive/data-trust-logger:1.0.1-beta
+      environment:
+        - APP_ENV=DEVELOPMENT_TESTING
       ports:
-        - 8001:8000
+        - 8002:8000
+    health-auditor:
+      image: brighthive/data-trust-logger:1.0.1-beta
+      environment:
+        - APP_ENV=DEVELOPMENT_TESTING
+      command: '--health-audit'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,3 @@ services:
         - APP_ENV=DEVELOPMENT_TESTING
       ports:
         - 8002:8000
-    health-auditor:
-      image: brighthive/data-trust-logger:1.0.1-beta
-      environment:
-        - APP_ENV=DEVELOPMENT_TESTING
-      command: '--health-audit'
-

--- a/tests/test_health_resource.py
+++ b/tests/test_health_resource.py
@@ -2,7 +2,6 @@ import json
 import re
 
 from expects import be, equal, expect, have_key, have_len
-from mock import patch
 from sqlalchemy.engine import ResultProxy
 
 


### PR DESCRIPTION
# Overview

Closes #3 

This PR adds new configuration options and also establishes a pattern for spinning up the auditor thread in `cmd.sh`.

# Walk through

1. Language. The names of the config variables align with our server names: "local" vs. "development testing" vs. "production." This departs from our previous practices, wherein we used "development" vs "sandbox" vs "production." 

2. Running the health auditor. Originally, I followed the pattern established in the Data Resources API, in which the `cmd.sh` spins up either the health auditor or the flask app. 

```
MODE=$@
if [ "$MODE" == "--health-audit" ]; then
    python health_audit_runner.py
else
    gunicorn -b 0.0.0.0 -w $WORKERS wsgi:app --worker-class gevent
fi
```

Then, the health auditor can reside on one container, and the flask app can reside in another. Unfortunately, this gets a little sticky, because the two services must share a JSON file. 

*Update!* The final version of the PR adjusts the `cmd.sh` file, so that we run both services in the same container.