### PR TITLE
Secure endpoints

### DIFF
--- a/.coveragec
+++ b/.coveragec
@@ -1,2 +1,2 @@
 [run]
-omit = */.local/*, migrations/*, */tests/*, */__init__.py, */responses.py
+omit = */.local/*, migrations/*, */tests/*, */__init__.py, */responses.py, */.virtualenvs/*

--- a/Pipfile
+++ b/Pipfile
@@ -20,6 +20,7 @@ sqlalchemy = "*"
 psycopg2-binary = "*"
 requests = "*"
 gevent = "*"
+brighthive-authlib = "*"
 
 [requires]
 python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -25,11 +25,10 @@
         },
         "brighthive-authlib": {
             "hashes": [
-                "sha256:43c5057d904c71a940b94245a624d3b5934c180a586facd49eb09320b450e130",
-                "sha256:b821e81eece6a7aa60e19cd424d013c5e740e1c29c0d5cebd6843b0db066e080"
+                "sha256:0c78cf9bb60b1e037023a4b55a8f44d2f616b67559525b73ede2ea373137120f"
             ],
             "index": "pypi",
-            "version": "==1.0.4"
+            "version": "==1.1.0"
         },
         "certifi": {
             "hashes": [
@@ -150,10 +149,10 @@
         },
         "idna": {
             "hashes": [
-                "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
-                "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
+                "sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb",
+                "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"
             ],
-            "version": "==2.8"
+            "version": "==2.9"
         },
         "itsdangerous": {
             "hashes": [
@@ -254,38 +253,38 @@
         },
         "pycryptodome": {
             "hashes": [
-                "sha256:012ca77c2105600e3c6aef43188101ac1d95052c633a4ae8fbebffab20c25f8a",
-                "sha256:05b4d865710f9a6378d3ada28195ff78e52642d3ecffe6fa9d379d870b9bf29d",
-                "sha256:07daddb98f98f771ba027f8f835bdb675aeb84effe41ed5221f520b267429354",
-                "sha256:09bf05a489fe10f9280a5e0163f195e7b9630cafb15f7d72fb9c8f5eb2afa84f",
-                "sha256:0a8d5f2dbb4bbe830ace54286b829bfa529f0853bedaab6225fcb2e6d1f7e356",
-                "sha256:1259b8ca49662b8a941177357f08147d858595c0042e63ff81e9628e925b5c9d",
-                "sha256:238d8b6dd27bd1a04816a68aa90a739e6dd23b192fcd83b50f9360958bff192a",
-                "sha256:2a57daef18a2022a5e4b6f7376c9ddd0c2d946e4b1f1e59b837f5bf295be7380",
-                "sha256:39e5ca2f66d1eac7abcba5ce1a03370d123dc6085620f1cd532dfee27e650178",
-                "sha256:3d516df693c195b8da3795e381429bd420e87081b7e6c2871c62c9897c812cda",
-                "sha256:3e486c5b7228e864665fc479e9f596b2547b5fe29c6f5c8ed3807784d06faed7",
-                "sha256:5029c46b0d41dfb763c3981c0af68eab029f06fe2b94f2299112fc18cf9e8d6d",
-                "sha256:5817c0b3c263025d851da96b90cbc7e95348008f88b990e90d10683dba376666",
-                "sha256:79320f1fc5c9ca682869087c565bb29ca6f334692e940d7365771e9a94382e12",
-                "sha256:887d08beca6368d3d70dc75126607ad76317a9fd07fe61323d8c3cb42add12b6",
-                "sha256:9163fec630495c10c767991e3f8dab32f4427bfb2dfeaa59bb28fe3e52ba66f2",
-                "sha256:95d324e603c5cec5d89e8595236bbf59ade5fe3a72d100ce61eebb323d598750",
-                "sha256:9927aa8a8cb4af681279b6f28a1dcb14e0eb556c1aea8413a1e27608a8516e0c",
-                "sha256:9948c2d5c5c0ee45ed44cee0e2eba2ce60a03be006ed3074521f3da3be162e72",
-                "sha256:a719bd708207fa219fcbf4c8ebbcbc52846045f78179d00445b429fdabdbc1c4",
-                "sha256:bc22ced26ebc46546798fa0141f4418f1db116dec517f0aeaecec87cf7b2416c",
-                "sha256:c41b7e10b72cef00cd63410f31fe50e72dc3a40eafbd146e288384fbe4208064",
-                "sha256:cdb0ad83a5d6bac986a37fcb7562bcbef0aabae8ea19505bab5cf83c4d18af12",
-                "sha256:d8e480f65ac7105cbc288eec2417dc61eaac6ed6e75595aa15b8c7c77c53a68b",
-                "sha256:da2d581da279bc7408d38e16ff77754f5448c4352f2acfe530a5d14d8fc6934a",
-                "sha256:de61091dd68326b600422cf731eb4810c4c6363f18a65bccd6061784b7454f5b",
-                "sha256:ec7d39589f9cfc2a8b83b1d2fc673441757c99d43283e97b2dd46e0e23730db8",
-                "sha256:f3204006869ab037604b1d9f045c4e84882ddd365e4ee8caa5eb1ff47a59188e",
-                "sha256:f4d2174e168d0eabd1fffaf88b4f62c2b6f30a67b8816f31024b8e48be3e2d75",
-                "sha256:fcff8c9d88d58880f7eda2139c7c444552a38f98a9e77ba5970b6e78f54ac358"
+                "sha256:07024fc364869eae8d6ac0d316e089956e6aeffe42dbdcf44fe1320d96becf7f",
+                "sha256:09b6d6bcc01a4eb1a2b4deeff5aa602a108ec5aed8ac75ae554f97d1d7f0a5ad",
+                "sha256:0e10f352ccbbcb5bb2dc4ecaf106564e65702a717d72ab260f9ac4c19753cfc2",
+                "sha256:1f4752186298caf2e9ff5354f2e694d607ca7342aa313a62005235d46e28cf04",
+                "sha256:2fbc472e0b567318fe2052281d5a8c0ae70099b446679815f655e9fbc18c3a65",
+                "sha256:3ec3dc2f80f71fd0c955ce48b81bfaf8914c6f63a41a738f28885a1c4892968a",
+                "sha256:426c188c83c10df71f053e04b4003b1437bae5cb37606440e498b00f160d71d0",
+                "sha256:626c0a1d4d83ec6303f970a17158114f75c3ba1736f7f2983f7b40a265861bd8",
+                "sha256:767ad0fb5d23efc36a4d5c2fc608ac603f3de028909bcf59abc943e0d0bc5a36",
+                "sha256:7ac729d9091ed5478af2b4a4f44f5335a98febbc008af619e4569a59fe503e40",
+                "sha256:83295a3fb5cf50c48631eb5b440cb5e9832d8c14d81d1d45f4497b67a9987de8",
+                "sha256:8be56bde3312e022d9d1d6afa124556460ad5c844c2fc63642f6af723c098d35",
+                "sha256:8f06556a8f7ea7b1e42eff39726bb0dca1c251205debae64e6eebea3cd7b438a",
+                "sha256:9230fcb5d948c3fb40049bace4d33c5d254f8232c2c0bba05d2570aea3ba4520",
+                "sha256:9378c309aec1f8cd8bad361ed0816a440151b97a2a3f6ffdaba1d1a1fb76873a",
+                "sha256:9977086e0f93adb326379897437373871b80501e1d176fec63c7f46fb300c862",
+                "sha256:9a94fca11fdc161460bd8659c15b6adef45c1b20da86402256eaf3addfaab324",
+                "sha256:9c739b7795ccf2ef1fdad8d44e539a39ad300ee6786e804ea7f0c6a786eb5343",
+                "sha256:b1e332587b3b195542e77681389c296e1837ca01240399d88803a075447d3557",
+                "sha256:c109a26a21f21f695d369ff9b87f5d43e0d6c768d8384e10bc74142bed2e092e",
+                "sha256:c818dc1f3eace93ee50c2b6b5c2becf7c418fa5dd1ba6fc0ef7db279ea21d5e4",
+                "sha256:cff31f5a8977534f255f729d5d2467526f2b10563a30bbdade92223e0bf264bd",
+                "sha256:d4f94368ce2d65873a87ad867eb3bf63f4ba81eb97a9ee66d38c2b71ce5a7439",
+                "sha256:d61b012baa8c2b659e9890011358455c0019a4108536b811602d2f638c40802a",
+                "sha256:d6e1bc5c94873bec742afe2dfadce0d20445b18e75c47afc0c115b19e5dd38dd",
+                "sha256:ea83bcd9d6c03248ebd46e71ac313858e0afd5aa2fa81478c0e653242f3eb476",
+                "sha256:ed5761b37615a1f222c5345bbf45272ae2cf8c7dff88a4f53a1e9f977cbb6d95",
+                "sha256:f011cd0062e54658b7086a76f8cf0f4222812acc66e219e196ea2d0a8849d0ed",
+                "sha256:f1add21b6d179179b3c177c33d18a2186a09cc0d3af41ff5ed3f377360b869f2",
+                "sha256:f655addaaaa9974108d4808f4150652589cada96074c87115c52e575bfcd87d5"
             ],
-            "version": "==3.9.6"
+            "version": "==3.9.7"
         },
         "python-jose": {
             "extras": [
@@ -306,11 +305,11 @@
         },
         "requests": {
             "hashes": [
-                "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4",
-                "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"
+                "sha256:43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee",
+                "sha256:b3f43d496c6daba4493e7c431722aeb7dbc6288f52a6e04e7b6023b0247817e6"
             ],
             "index": "pypi",
-            "version": "==2.22.0"
+            "version": "==2.23.0"
         },
         "rsa": {
             "hashes": [
@@ -497,10 +496,10 @@
         },
         "zipp": {
             "hashes": [
-                "sha256:5c56e330306215cd3553342cfafc73dda2c60792384117893f3a83f8a1209f50",
-                "sha256:d65287feb793213ffe11c0f31b81602be31448f38aeb8ffc2eb286c4f6f6657e"
+                "sha256:12248a63bbdf7548f89cb4c7cda4681e537031eda29c02ea29674bc6854460c2",
+                "sha256:7c0f8e91abc0dc07a5068f315c52cb30c66bfbc581e5b50704c8a2f6ebae794a"
             ],
-            "version": "==2.2.0"
+            "version": "==3.0.0"
         }
     }
 }

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a7e64195cecab701a43986089f3b12fa348d048744220626ecfeda59ae5df3a0"
+            "sha256": "f570088787f063aa6ae26941c316b55911333d078a0301ee409b694bfb2ce318"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -22,6 +22,14 @@
                 "sha256:c033f63d028b9a58e3ab0c2c7d0532ab4bfa7452bfc788fbfe3ddabd327b181a"
             ],
             "version": "==8.0.0"
+        },
+        "brighthive-authlib": {
+            "hashes": [
+                "sha256:43c5057d904c71a940b94245a624d3b5934c180a586facd49eb09320b450e130",
+                "sha256:b821e81eece6a7aa60e19cd424d013c5e740e1c29c0d5cebd6843b0db066e080"
+            ],
+            "index": "pypi",
+            "version": "==1.0.4"
         },
         "certifi": {
             "hashes": [
@@ -44,6 +52,13 @@
             ],
             "version": "==7.0"
         },
+        "ecdsa": {
+            "hashes": [
+                "sha256:867ec9cf6df0b03addc8ef66b56359643cb5d0c1dc329df76ba7ecfe256c8061",
+                "sha256:8f12ac317f8a1318efa75757ef0a651abe12e51fc1af8838fb91079445227277"
+            ],
+            "version": "==0.15"
+        },
         "flask": {
             "hashes": [
                 "sha256:13f9f196f330c7c2c5d7a5cf91af894110ca0215ac051b5844701f2bfd934d52",
@@ -62,11 +77,11 @@
         },
         "flask-restful": {
             "hashes": [
-                "sha256:ecd620c5cc29f663627f99e04f17d1f16d095c83dc1d618426e2ad68b03092f8",
-                "sha256:f8240ec12349afe8df1db168ea7c336c4e5b0271a36982bff7394f93275f2ca9"
+                "sha256:5ea9a5991abf2cb69b4aac19793faac6c032300505b325687d7c305ffaa76915",
+                "sha256:d891118b951921f1cec80cabb4db98ea6058a35e6404788f9e70d5b243813ec2"
             ],
             "index": "pypi",
-            "version": "==0.3.7"
+            "version": "==0.3.8"
         },
         "gevent": {
             "hashes": [
@@ -230,6 +245,58 @@
             "index": "pypi",
             "version": "==2.8.4"
         },
+        "pyasn1": {
+            "hashes": [
+                "sha256:39c7e2ec30515947ff4e87fb6f456dfc6e84857d34be479c9d4a4ba4bf46aa5d",
+                "sha256:aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba"
+            ],
+            "version": "==0.4.8"
+        },
+        "pycryptodome": {
+            "hashes": [
+                "sha256:012ca77c2105600e3c6aef43188101ac1d95052c633a4ae8fbebffab20c25f8a",
+                "sha256:05b4d865710f9a6378d3ada28195ff78e52642d3ecffe6fa9d379d870b9bf29d",
+                "sha256:07daddb98f98f771ba027f8f835bdb675aeb84effe41ed5221f520b267429354",
+                "sha256:09bf05a489fe10f9280a5e0163f195e7b9630cafb15f7d72fb9c8f5eb2afa84f",
+                "sha256:0a8d5f2dbb4bbe830ace54286b829bfa529f0853bedaab6225fcb2e6d1f7e356",
+                "sha256:1259b8ca49662b8a941177357f08147d858595c0042e63ff81e9628e925b5c9d",
+                "sha256:238d8b6dd27bd1a04816a68aa90a739e6dd23b192fcd83b50f9360958bff192a",
+                "sha256:2a57daef18a2022a5e4b6f7376c9ddd0c2d946e4b1f1e59b837f5bf295be7380",
+                "sha256:39e5ca2f66d1eac7abcba5ce1a03370d123dc6085620f1cd532dfee27e650178",
+                "sha256:3d516df693c195b8da3795e381429bd420e87081b7e6c2871c62c9897c812cda",
+                "sha256:3e486c5b7228e864665fc479e9f596b2547b5fe29c6f5c8ed3807784d06faed7",
+                "sha256:5029c46b0d41dfb763c3981c0af68eab029f06fe2b94f2299112fc18cf9e8d6d",
+                "sha256:5817c0b3c263025d851da96b90cbc7e95348008f88b990e90d10683dba376666",
+                "sha256:79320f1fc5c9ca682869087c565bb29ca6f334692e940d7365771e9a94382e12",
+                "sha256:887d08beca6368d3d70dc75126607ad76317a9fd07fe61323d8c3cb42add12b6",
+                "sha256:9163fec630495c10c767991e3f8dab32f4427bfb2dfeaa59bb28fe3e52ba66f2",
+                "sha256:95d324e603c5cec5d89e8595236bbf59ade5fe3a72d100ce61eebb323d598750",
+                "sha256:9927aa8a8cb4af681279b6f28a1dcb14e0eb556c1aea8413a1e27608a8516e0c",
+                "sha256:9948c2d5c5c0ee45ed44cee0e2eba2ce60a03be006ed3074521f3da3be162e72",
+                "sha256:a719bd708207fa219fcbf4c8ebbcbc52846045f78179d00445b429fdabdbc1c4",
+                "sha256:bc22ced26ebc46546798fa0141f4418f1db116dec517f0aeaecec87cf7b2416c",
+                "sha256:c41b7e10b72cef00cd63410f31fe50e72dc3a40eafbd146e288384fbe4208064",
+                "sha256:cdb0ad83a5d6bac986a37fcb7562bcbef0aabae8ea19505bab5cf83c4d18af12",
+                "sha256:d8e480f65ac7105cbc288eec2417dc61eaac6ed6e75595aa15b8c7c77c53a68b",
+                "sha256:da2d581da279bc7408d38e16ff77754f5448c4352f2acfe530a5d14d8fc6934a",
+                "sha256:de61091dd68326b600422cf731eb4810c4c6363f18a65bccd6061784b7454f5b",
+                "sha256:ec7d39589f9cfc2a8b83b1d2fc673441757c99d43283e97b2dd46e0e23730db8",
+                "sha256:f3204006869ab037604b1d9f045c4e84882ddd365e4ee8caa5eb1ff47a59188e",
+                "sha256:f4d2174e168d0eabd1fffaf88b4f62c2b6f30a67b8816f31024b8e48be3e2d75",
+                "sha256:fcff8c9d88d58880f7eda2139c7c444552a38f98a9e77ba5970b6e78f54ac358"
+            ],
+            "version": "==3.9.6"
+        },
+        "python-jose": {
+            "extras": [
+                "pycryptodome"
+            ],
+            "hashes": [
+                "sha256:1ac4caf4bfebd5a70cf5bd82702ed850db69b0b6e1d0ae7368e5f99ac01c9571",
+                "sha256:8484b7fdb6962e9d242cce7680469ecf92bda95d10bbcbbeb560cacdff3abfce"
+            ],
+            "version": "==3.1.0"
+        },
         "pytz": {
             "hashes": [
                 "sha256:1c557d7d0e871de1f5ccd5833f60fb2550652da6be2693c1e02300743d21500d",
@@ -244,6 +311,13 @@
             ],
             "index": "pypi",
             "version": "==2.22.0"
+        },
+        "rsa": {
+            "hashes": [
+                "sha256:14ba45700ff1ec9eeb206a2ce76b32814958a98e372006c8fb76ba820211be66",
+                "sha256:1a836406405730121ae9823e19c6e806c62bbad73f890574fff50efa4122c487"
+            ],
+            "version": "==4.0"
         },
         "six": {
             "hashes": [
@@ -268,10 +342,10 @@
         },
         "werkzeug": {
             "hashes": [
-                "sha256:1e0dedc2acb1f46827daa2e399c1485c8fa17c0d8e70b6b875b4e7f54bf408d2",
-                "sha256:b353856d37dec59d6511359f97f6a4b2468442e454bd1c98298ddce53cac1f04"
+                "sha256:169ba8a33788476292d04186ab33b01d6add475033dfc07215e6d219cc077096",
+                "sha256:6dc65cf9091cf750012f56f2cad759fa9e879f511b5ff8685e456b4e3bf90d16"
             ],
-            "version": "==0.16.1"
+            "version": "==1.0.0"
         }
     },
     "develop": {
@@ -423,10 +497,10 @@
         },
         "zipp": {
             "hashes": [
-                "sha256:ccc94ed0909b58ffe34430ea5451f07bc0c76467d7081619a454bf5c98b89e28",
-                "sha256:feae2f18633c32fc71f2de629bfb3bd3c9325cd4419642b1f1da42ee488d9b98"
+                "sha256:5c56e330306215cd3553342cfafc73dda2c60792384117893f3a83f8a1209f50",
+                "sha256:d65287feb793213ffe11c0f31b81602be31448f38aeb8ffc2eb286c4f6f6657e"
             ],
-            "version": "==2.1.0"
+            "version": "==2.2.0"
         }
     }
 }

--- a/data_trust_logger/api/health.py
+++ b/data_trust_logger/api/health.py
@@ -5,6 +5,7 @@ A simple API for returning health metrics about the MCI and DR APIs.
 """
 import json
 
+from brighthive_authlib import token_required
 from flask import Blueprint, request
 from flask_restful import Api, Resource
 from sqlalchemy import create_engine
@@ -22,6 +23,7 @@ class HealthAuditResource(Resource):
     def __init__(self):
         self.response = resp.ResponseBody()
 
+    @token_required(config.oauth2_provider)
     def get(self):
         metrics_data = {}
 

--- a/data_trust_logger/api/health.py
+++ b/data_trust_logger/api/health.py
@@ -33,6 +33,7 @@ class HealthAuditResource(Resource):
         return self.response.get_one_response(metrics_data)
 
 
+
 health_bp = Blueprint('health_ep', __name__)
 health_api = Api(health_bp)
 health_api.add_resource(HealthAuditResource, '/health')

--- a/data_trust_logger/api/logger.py
+++ b/data_trust_logger/api/logger.py
@@ -5,13 +5,18 @@ is to enable web applications (such as Facet) to have a means of providing outpu
 
 """
 
-import logging
 import json
+import logging
 import sys
+
+from brighthive_authlib import token_required
 from flask import Blueprint, request
-from flask_restful import Resource, Api
+from flask_restful import Api, Resource
 
 import data_trust_logger.utilities.responses as resp
+from data_trust_logger.config import ConfigurationFactory
+
+config = ConfigurationFactory.from_env()
 
 
 class LogResource(Resource):
@@ -28,6 +33,7 @@ class LogResource(Resource):
 
         self.log.addHandler(log_handler)
 
+    @token_required(config.oauth2_provider)
     def post(self):
         try:
             data = request.get_json(force=True)

--- a/data_trust_logger/app/app.py
+++ b/data_trust_logger/app/app.py
@@ -1,9 +1,25 @@
 """Data Trust Logger Application."""
-from flask import Flask
+import brighthive_authlib
+from brighthive_authlib import OAuth2ProviderError
+from flask import Flask, jsonify
 from flask_cors import CORS
+from flask_restful import Api
+
+from flask import Blueprint
 
 from data_trust_logger.api import health_bp, log_bp
 
+
+def handle_errors(e):
+    print("Incoming error:", e)
+    if isinstance(e, OAuth2ProviderError):
+        response = jsonify({'message': 'Access Denied'})
+        response.status_code = 401
+        return response
+    else:
+        response = jsonify({'error': 'An unknown error occured'})
+        response.status_code = 400
+        return response
 
 def create_app(environment: str = None):
     """Create the Flask application.
@@ -18,5 +34,7 @@ def create_app(environment: str = None):
 
     app.register_blueprint(health_bp)
     app.register_blueprint(log_bp)
+
+    app.register_error_handler(Exception, handle_errors)
 
     return app

--- a/data_trust_logger/app/app.py
+++ b/data_trust_logger/app/app.py
@@ -11,13 +11,12 @@ from data_trust_logger.api import health_bp, log_bp
 
 
 def handle_errors(e):
-    print("Incoming error:", e)
     if isinstance(e, OAuth2ProviderError):
         response = jsonify({'message': 'Access Denied'})
         response.status_code = 401
         return response
     else:
-        response = jsonify({'error': 'An unknown error occured'})
+        response = jsonify({'error': 'An unknown error occurred'})
         response.status_code = 400
         return response
 

--- a/data_trust_logger/config/config.example.json
+++ b/data_trust_logger/config/config.example.json
@@ -26,10 +26,8 @@
         "oauth2": {
             "client_id": "xxxxxxxxxx", 
             "client_secret": "xxxxxxxxxx",
-            "oauth2_audience": "http://localhost:8000",
             "oauth2_url": "",
-            "oauth2_provider": "",
-            "oauth2_algorithms": ""
+            "oauth2_provider": ""
         }
     },
     "development_testing": { },

--- a/data_trust_logger/config/config.example.json
+++ b/data_trust_logger/config/config.example.json
@@ -16,11 +16,13 @@
             "mci_psql_port": "5432",
             "mci_psql_database": "mci_dev"
         },
-        "auth_access": {
-            "client_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxx", 
-            "client_secret": "xxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-            "audience": "http://localhost:8000",
-            "oauth2_url": "https://<url_to_authserver>/oauth/token"
+        "oauth2": {
+            "client_id": "xxxxxxxxxx", 
+            "client_secret": "xxxxxxxxxx",
+            "oauth2_audience": "http://localhost:8000",
+            "oauth2_url": "<url>/oauth/token",
+            "oauth2_provider": "",
+            "oauth2_algorithms": ""
         }
     },
     "development_testing": { },

--- a/data_trust_logger/config/config.example.json
+++ b/data_trust_logger/config/config.example.json
@@ -20,7 +20,7 @@
             "client_id": "xxxxxxxxxx", 
             "client_secret": "xxxxxxxxxx",
             "oauth2_audience": "http://localhost:8000",
-            "oauth2_url": "<url>/oauth/token",
+            "oauth2_url": "",
             "oauth2_provider": "",
             "oauth2_algorithms": ""
         }

--- a/data_trust_logger/config/config.py
+++ b/data_trust_logger/config/config.py
@@ -83,14 +83,12 @@ class Configuration(object):
                 self.client_id = fields['oauth2']['client_id']
                 self.client_secret = fields['oauth2']['client_secret']
                 
-                oauth2_url_base = fields['oauth2']['oauth2_url']
-                self.oauth2_url = f"{oauth2_url_base}/oauth/token"
-                self.oauth2_jwks_url = f"{oauth2_url_base}/.well-known/jwks.json"
-                self.oauth2_url_base = oauth2_url_base
-                self.oauth2_audience = fields['oauth2']['oauth2_audience']
-                self.oauth2_provider = fields['oauth2']['oauth2_provider']
-                self.oauth2_algorithms = fields['oauth2']['oauth2_algorithms']
-
+                self.oauth2_url_base = fields['oauth2']['oauth2_url']
+                self.oauth2_url = f"{self.oauth2_url_base}/oauth/token"
+                self.oauth2_audience = fields["oauth2"]["oauth2_audience"]
+                self.brighthive_auth_url = fields['brighthive_auth']['brighthive_auth_url']
+                self.brighthive_auth_provider = fields["brighthive_auth"]["brighthive_auth_provider"]
+                
                 self.environment = environment
                 self.debug = True
                 self.testing = True
@@ -126,14 +124,11 @@ class Configuration(object):
             object: The OAuth 2.0 Provider.
         """
         auth_config = AuthLibConfiguration(
-            provider=self.oauth2_provider, 
-            base_url=self.oauth2_url_base,
-            jwks_url=self.oauth2_jwks_url, 
-            algorithms=self.oauth2_algorithms, 
-            audience=self.oauth2_audience)
+            provider=self.brighthive_auth_provider, 
+            base_url=self.brighthive_auth_url)
 
         oauth2_provider = OAuth2ProviderFactory.get_provider(
-            self.oauth2_provider, auth_config)
+            self.brighthive_auth_provider, auth_config)
 
         return oauth2_provider
 

--- a/data_trust_logger/config/config.py
+++ b/data_trust_logger/config/config.py
@@ -80,11 +80,14 @@ class Configuration(object):
 
                 self.client_id = fields['oauth2']['client_id']
                 self.client_secret = fields['oauth2']['client_secret']
+                
+                oauth2_url_base = fields['oauth2']['oauth2_url']
+                self.oauth2_url = f"{oauth2_url_base}/oauth/token"
+                self.oauth2_jwks_url = f"{oauth2_url_base}/.well-known/jwks.json"
+                self.oauth2_url_base = oauth2_url_base
                 self.oauth2_audience = fields['oauth2']['oauth2_audience']
-                self.oauth2_url = fields['oauth2']['oauth2_url']
                 self.oauth2_provider = fields['oauth2']['oauth2_provider']
                 self.oauth2_algorithms = fields['oauth2']['oauth2_algorithms']
-                self.oauth2_jwks_url = f"{self.oauth2_url}/.well-known/jwks.json"
 
                 self.environment = environment
                 self.debug = True
@@ -122,7 +125,7 @@ class Configuration(object):
         """
         auth_config = AuthLibConfiguration(
             provider=self.oauth2_provider, 
-            base_url=self.oauth2_url,
+            base_url=self.oauth2_url_base,
             jwks_url=self.oauth2_jwks_url, 
             algorithms=self.oauth2_algorithms, 
             audience=self.oauth2_audience)

--- a/data_trust_logger/utilities/secure_requests.py
+++ b/data_trust_logger/utilities/secure_requests.py
@@ -24,7 +24,7 @@ def get_access_token():
     data = {
         'client_id': config.client_id, 
         'client_secret': config.client_secret,
-        'audience': config.audience, 
+        'audience': config.oauth2_audience, 
         'grant_type': 'client_credentials'
     }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
 version: '3'
 services: 
     data-trust-logger: 
-      image: brighthive/data-trust-logger:1.0.1-beta
+      image: brighthive/data-trust-logger:local
       environment:
         - APP_ENV=LOCAL
       ports:
-        - 8002:8000
+        - 8002:8002

--- a/tests/test_health_resource.py
+++ b/tests/test_health_resource.py
@@ -6,6 +6,7 @@ from sqlalchemy.engine import ResultProxy
 
 
 def _healthcheck_response(client, metrics_blob, mocker):
+    mocker.patch('brighthive_authlib.providers.BrightHiveProvider.validate_token', return_value=True)
     mocker.patch("json.load", return_value=metrics_blob)
 
     response = client.get('/health')

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -7,10 +7,19 @@ from expects import expect, be, equal, have_key
 
 
 class TestLogger:
-    def test_post_log(self, client):
+    def test_log_empty_body(self, client, mocker):
+        mocker.patch('brighthive_authlib.providers.BrightHiveProvider.validate_token', return_value=True)
         headers = {'content-type': 'application/json'}
         response = client.post('/log', headers=headers)
+
         expect(response.status_code).to(equal(400))
+        expect(response.json['messages']).to(equal(['Empty request body.']))
+    
+    def test_log_with_data(self, client, mocker):
+        mocker.patch('brighthive_authlib.providers.BrightHiveProvider.validate_token', return_value=True)
+        headers = {'content-type': 'application/json'}
         message = {'status': 'error', 'type': 'a log thing', 'foo': 'bar'}
         response = client.post('/log', data=json.dumps(message), headers=headers)
-        print(response.json)
+
+        expect(response.status_code).to(equal(201))
+        expect(response.json['messages']).to(equal(['Successfully logged message']))


### PR DESCRIPTION
This PR accomplishes the following:

* upgrades Authlib (n.b., the latest release of authlib comes with a `BrightHiveProvider`, which validates tokens via authserver)
* wraps `health` and `log` endpoints in Authlib's `token_required` decorator
* configures the OAuth2Provider/BrightHiveProvider (and passes this provider into the above-mentioned decorator)

Handles clubhouse story: https://app.clubhouse.io/brighthive/story/313/secure-api-endpoints-using-new-authlib
