### PR TITLE
Dr mappings

### DIFF
--- a/data_trust_logger/config/config.example.json
+++ b/data_trust_logger/config/config.example.json
@@ -6,7 +6,10 @@
             "dr_psql_password": "test_password",
             "dr_psql_hostname": "localhost",
             "dr_psql_port": "5433",
-            "dr_psql_database": "data_resource_dev"
+            "dr_psql_database": "data_resource_dev",
+            "table_to_ep_mappings": {
+                "programs": "myjourney_programs"
+            }
         },
         "master_client_index": {
             "mci_url": "http://0.0.0.0:8000",
@@ -14,7 +17,11 @@
             "mci_psql_password": "test_password",
             "mci_psql_hostname": "localhost" ,
             "mci_psql_port": "5432",
-            "mci_psql_database": "mci_dev"
+            "mci_psql_database": "mci_dev",
+            "table_to_ep_mappings": {
+                "individual": "users",
+                "ethnicity_race": "ethnicity"
+            }
         },
         "auth_access": {
             "client_id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxx", 

--- a/data_trust_logger/config/config.py
+++ b/data_trust_logger/config/config.py
@@ -67,6 +67,7 @@ class Configuration(object):
                 self.dr_psql_hostname = fields['data_resources']['dr_psql_hostname']
                 self.dr_psql_port = fields['data_resources']['dr_psql_port']
                 self.dr_psql_database = fields['data_resources']['dr_psql_database']
+                self.data_resources_mappings = fields['data_resources']['table_to_ep_mappings']
 
                 self.mci_url = fields['master_client_index']['mci_url']
                 self.mci_psql_user = fields['master_client_index']['mci_psql_user']
@@ -74,6 +75,7 @@ class Configuration(object):
                 self.mci_psql_hostname = fields['master_client_index']['mci_psql_hostname']
                 self.mci_psql_port = fields['master_client_index']['mci_psql_port']
                 self.mci_psql_database = fields['master_client_index']['mci_psql_database']
+                self.mci_mappings = fields['master_client_index']['table_to_ep_mappings']
 
                 self.client_id = fields['auth_access']['client_id']
                 self.client_secret = fields['auth_access']['client_secret']

--- a/data_trust_logger/health_audit/data_resources_collector.py
+++ b/data_trust_logger/health_audit/data_resources_collector.py
@@ -30,15 +30,10 @@ def instantiate_data_resources_collector():
 
     metatables = ['alembic_version', 'checksums', 'logs']
     data_resources_tablenames = [endpoint for endpoint in table_names if endpoint not in metatables and "\\" not in endpoint]
-    
-    # Key (table name): Value (endpoint name)
-    table_to_ep_mappings = {
-        'users': 'myjourney/users'
-    }
 
     return HealthMetricsCollector(
         engine=data_resources_engine, 
         api_url=config.dr_url,
         tablenames=data_resources_tablenames,
-        table_to_ep_mappings=table_to_ep_mappings
+        table_to_ep_mappings=config.data_resources_mappings
     )

--- a/data_trust_logger/health_audit/data_resources_collector.py
+++ b/data_trust_logger/health_audit/data_resources_collector.py
@@ -29,10 +29,16 @@ def instantiate_data_resources_collector():
         table_names = data_resources_engine.table_names()
 
     metatables = ['alembic_version', 'checksums', 'logs']
-    data_resources_endpoints = [endpoint for endpoint in table_names if endpoint not in metatables and "\\" not in endpoint]
+    data_resources_tablenames = [endpoint for endpoint in table_names if endpoint not in metatables and "\\" not in endpoint]
+    
+    # Key (table name): Value (endpoint name)
+    table_to_ep_mappings = {
+        'users': 'myjourney/users'
+    }
 
     return HealthMetricsCollector(
         engine=data_resources_engine, 
         api_url=config.dr_url,
-        endpoints=data_resources_endpoints
+        tablenames=data_resources_tablenames,
+        table_to_ep_mappings=table_to_ep_mappings
     )

--- a/data_trust_logger/health_audit/mci_collector.py
+++ b/data_trust_logger/health_audit/mci_collector.py
@@ -23,15 +23,10 @@ def instantiate_mci_collector():
         mci_engine = None
     
     mci_tablenames = ['individual', 'source', 'gender', 'address', 'disposition', 'ethnicity_race', 'employment_status', 'education_level']
-    # Key (table name): Value (endpoint name)
-    table_to_ep_mappings = {
-        'individual': 'users',
-        'ethnicity_race': 'ethnicity',
-    }
-
+    
     return HealthMetricsCollector(
         engine=mci_engine, 
         api_url=config.mci_url,
         tablenames=mci_tablenames,
-        table_to_ep_mappings=table_to_ep_mappings
+        table_to_ep_mappings=config.mci_mappings
     )

--- a/data_trust_logger/health_audit/mci_collector.py
+++ b/data_trust_logger/health_audit/mci_collector.py
@@ -22,15 +22,16 @@ def instantiate_mci_collector():
         logger.error(error)
         mci_engine = None
     
-    mci_endpoints = ['users', 'source', 'gender', 'address', 'disposition', 'ethnicity', 'employment_status', 'education_level']
+    mci_tablenames = ['individual', 'source', 'gender', 'address', 'disposition', 'ethnicity_race', 'employment_status', 'education_level']
+    # Key (table name): Value (endpoint name)
     table_to_ep_mappings = {
-        'users': 'individual',
-        'ethnicity': 'ethnicity_race',
+        'individual': 'users',
+        'ethnicity_race': 'ethnicity',
     }
 
     return HealthMetricsCollector(
         engine=mci_engine, 
         api_url=config.mci_url,
-        endpoints=mci_endpoints,
+        tablenames=mci_tablenames,
         table_to_ep_mappings=table_to_ep_mappings
     )

--- a/data_trust_logger/health_audit/metrics_collector.py
+++ b/data_trust_logger/health_audit/metrics_collector.py
@@ -6,10 +6,10 @@ from data_trust_logger.utilities import get_access_token, secure_requests
 
 
 class HealthMetricsCollector(object):
-    def __init__(self, engine, api_url, endpoints, table_to_ep_mappings={}):
+    def __init__(self, engine, api_url, tablenames, table_to_ep_mappings={}):
         self.engine = engine 
         self.api_url = api_url
-        self.endpoints = endpoints 
+        self.tablenames = tablenames 
         self.table_to_ep_mappings = table_to_ep_mappings
 
     def _get_endpoint_status(self, api_ep: str, token: str):
@@ -36,14 +36,14 @@ class HealthMetricsCollector(object):
         metrics_list = []
         token = get_access_token()
 
-        for endpoint in self.endpoints:
+        for table in self.tablenames:
             try:
-                tablename = self.table_to_ep_mappings[endpoint]
+                endpoint = self.table_to_ep_mappings[table]
             except KeyError:
-                tablename = endpoint
+                endpoint = table
             
             status, last_accessed = self._get_endpoint_status(f"{self.api_url}/{endpoint}", token)
-            count = self._get_endpoint_record_count(self.engine, tablename)
+            count = self._get_endpoint_record_count(self.engine, table)
             
             metrics_list.append({
                 'endpoint': endpoint,


### PR DESCRIPTION
This PR slightly modifies the Collector to map `tablenames` (i.e., what's in the database) with `endpoints` (i.e., what in the API). 

The config.json stores the mappings, which can apply to both/either the MCI and/or the DR API.

We need this immediate solution to accommodate the unusual schema in the VA Data Trust. In the future, we will retrieve the DR API endpoints dynamically (pending changes in the DR API itself).

Closes #11 