### PR TITLE
task: Stringify the timezone

### DIFF
--- a/data_trust_logger/health_audit/metrics_collector.py
+++ b/data_trust_logger/health_audit/metrics_collector.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 import requests
 
@@ -19,7 +19,7 @@ class HealthMetricsCollector(object):
         except Exception:
             status = 503
         
-        last_accessed = datetime.utcnow().strftime('%Y-%m-%d %H:%M')
+        last_accessed = str(datetime.now(timezone.utc))
         
         return status, last_accessed
 


### PR DESCRIPTION
Previously, the Logger API returned a string version of the `last_accessed` timestamp, but the string formatting omitted the timezone. 

This PR returns the full UTC timestamp (which allows client-side applications to make clear sense of it). 

Closes https://github.com/brighthive/facet/issues/235