### PR TITLE
Fixes

### DIFF
--- a/build_deployment.sh
+++ b/build_deployment.sh
@@ -1,6 +1,6 @@
 ORGANIZATION=brighthive
 IMAGE_NAME=data-trust-logger
-VERSION=0.1.0-76e27
+VERSION=1.0.1
 AWS_ECR_REPO=396527728813.dkr.ecr.us-east-2.amazonaws.com
 
 docker build -t $ORGANIZATION/$IMAGE_NAME:$VERSION -f Dockerfile .

--- a/data_trust_logger/health_audit/data_resources_collector.py
+++ b/data_trust_logger/health_audit/data_resources_collector.py
@@ -1,4 +1,3 @@
-from sqlalchemy import create_engine
 from sqlalchemy.exc import OperationalError
 
 from data_trust_logger.config import ConfigurationFactory
@@ -9,12 +8,12 @@ from data_trust_logger.utilities.basic_logger import basic_logger
 config = ConfigurationFactory.from_env()
 
 
-def instantiate_data_resources_collector():
+def instantiate_data_resources_collector(data_resources_engine):
     try:
         # create_engine() itself does not establish a DB connection.
         # We call `connect()` to assess the database health early on.
-        data_resources_engine = create_engine(config.dr_psql_uri)
-        data_resources_engine.connect()
+        connection = data_resources_engine.connect()
+        connection.close()
     except (ValueError, OperationalError) as error:
         basic_logger.error("Data Resources HealthMetricsCollector cannot connect to database.")
         basic_logger.error(error)

--- a/data_trust_logger/health_audit/data_resources_collector.py
+++ b/data_trust_logger/health_audit/data_resources_collector.py
@@ -1,14 +1,12 @@
-import logging
-
 from sqlalchemy import create_engine
 from sqlalchemy.exc import OperationalError
 
 from data_trust_logger.config import ConfigurationFactory
 from data_trust_logger.health_audit.metrics_collector import \
     HealthMetricsCollector
+from data_trust_logger.utilities.basic_logger import basic_logger
 
 config = ConfigurationFactory.from_env()
-logger = logging.getLogger(__name__)
 
 
 def instantiate_data_resources_collector():
@@ -18,8 +16,8 @@ def instantiate_data_resources_collector():
         data_resources_engine = create_engine(config.dr_psql_uri)
         data_resources_engine.connect()
     except (ValueError, OperationalError) as error:
-        logger.error("Data Resources HealthMetricsCollector cannot connect to database.")
-        logger.error(error)
+        basic_logger.error("Data Resources HealthMetricsCollector cannot connect to database.")
+        basic_logger.error(error)
         data_resources_engine = None
         table_names = []
     else:

--- a/data_trust_logger/health_audit/health_auditor.py
+++ b/data_trust_logger/health_audit/health_auditor.py
@@ -2,23 +2,29 @@ import json
 import os
 from threading import Thread
 from time import sleep
+from sqlalchemy import create_engine
 
+from data_trust_logger.config import ConfigurationFactory
 from data_trust_logger.health_audit.data_resources_collector import \
     instantiate_data_resources_collector
 from data_trust_logger.health_audit.mci_collector import \
     instantiate_mci_collector
 
+config = ConfigurationFactory.from_env()
 
 class HealthAuditor(Thread):
     def __init__(self):
         Thread.__init__(self)
 
     def audit(self):
+        mci_engine = create_engine(config.mci_psql_uri)
+        data_resources_engine = create_engine(config.dr_psql_uri)
+
         while True:
-            mci_collector = instantiate_mci_collector()
+            mci_collector = instantiate_mci_collector(mci_engine)
             mci_metrics = mci_collector.collect_metrics()
             
-            data_resources_collector = instantiate_data_resources_collector()
+            data_resources_collector = instantiate_data_resources_collector(data_resources_engine)
             data_resources_metrics = data_resources_collector.collect_metrics()
 
             metrics_blob = {

--- a/data_trust_logger/health_audit/mci_collector.py
+++ b/data_trust_logger/health_audit/mci_collector.py
@@ -1,13 +1,11 @@
-import logging
-
 from sqlalchemy import create_engine
 from sqlalchemy.exc import OperationalError
 
 from data_trust_logger.config import ConfigurationFactory
 from data_trust_logger.health_audit.metrics_collector import \
     HealthMetricsCollector
+from data_trust_logger.utilities.basic_logger import basic_logger
 
-logger = logging.getLogger(__name__)
 config = ConfigurationFactory.from_env()
 
 
@@ -18,8 +16,8 @@ def instantiate_mci_collector():
         mci_engine = create_engine(config.mci_psql_uri)
         mci_engine.connect()
     except (ValueError, OperationalError) as error:
-        logger.error("MCI HealthMetricsCollector cannot connect to database.")
-        logger.error(error)
+        basic_logger.error("MCI HealthMetricsCollector cannot connect to database.")
+        basic_logger.error(error)
         mci_engine = None
     
     mci_tablenames = ['individual', 'source', 'gender', 'address', 'disposition', 'ethnicity_race', 'employment_status', 'education_level']

--- a/data_trust_logger/health_audit/mci_collector.py
+++ b/data_trust_logger/health_audit/mci_collector.py
@@ -9,12 +9,12 @@ from data_trust_logger.utilities.basic_logger import basic_logger
 config = ConfigurationFactory.from_env()
 
 
-def instantiate_mci_collector():
+def instantiate_mci_collector(mci_engine):
     try:
         # create_engine() itself does not establish a DB connection.
         # We call `connect()` to assess the database health early on.
-        mci_engine = create_engine(config.mci_psql_uri)
-        mci_engine.connect()
+        connection = mci_engine.connect()
+        connection.close()
     except (ValueError, OperationalError) as error:
         basic_logger.error("MCI HealthMetricsCollector cannot connect to database.")
         basic_logger.error(error)

--- a/data_trust_logger/health_audit/metrics_collector.py
+++ b/data_trust_logger/health_audit/metrics_collector.py
@@ -25,8 +25,10 @@ class HealthMetricsCollector(object):
 
     def _get_endpoint_record_count(self, engine: object, endpoint: str):
         try:
-            result = engine.execute(f"SELECT COUNT(*) from {endpoint}")
+            connection = engine.connect()
+            result = connection.execute(f"SELECT COUNT(*) from {endpoint}")
             count, = result.fetchone()
+            connection.close()
         except Exception:
             count = -1
         

--- a/data_trust_logger/health_audit/metrics_collector.py
+++ b/data_trust_logger/health_audit/metrics_collector.py
@@ -34,7 +34,6 @@ class HealthMetricsCollector(object):
 
     def collect_metrics(self):
         metrics_list = []
-
         token = read_token()
 
         for table in self.tablenames:

--- a/data_trust_logger/health_audit/metrics_collector.py
+++ b/data_trust_logger/health_audit/metrics_collector.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone
 
 import requests
 
-from data_trust_logger.utilities import get_access_token, secure_requests
+from data_trust_logger.utilities import get_access_token, read_token, secure_requests
 
 
 class HealthMetricsCollector(object):
@@ -34,7 +34,8 @@ class HealthMetricsCollector(object):
 
     def collect_metrics(self):
         metrics_list = []
-        token = get_access_token()
+
+        token = read_token()
 
         for table in self.tablenames:
             try:
@@ -42,8 +43,14 @@ class HealthMetricsCollector(object):
             except KeyError:
                 endpoint = table
             
-            status, last_accessed = self._get_endpoint_status(f"{self.api_url}/{endpoint}", token)
             count = self._get_endpoint_record_count(self.engine, table)
+            
+            # Request a new access token if the token has expired, i.e., the endpoint raises a 401.
+            status, last_accessed = self._get_endpoint_status(f"{self.api_url}/{endpoint}", token)
+            if status == 401:
+                get_access_token()
+                token = read_token() 
+                status, last_accessed = self._get_endpoint_status(f"{self.api_url}/{endpoint}", token)
             
             metrics_list.append({
                 'endpoint': endpoint,

--- a/data_trust_logger/utilities/__init__.py
+++ b/data_trust_logger/utilities/__init__.py
@@ -1,1 +1,1 @@
-from data_trust_logger.utilities.secure_requests import get_access_token, secure_get
+from data_trust_logger.utilities.secure_requests import get_access_token, read_token, secure_get

--- a/data_trust_logger/utilities/__init__.py
+++ b/data_trust_logger/utilities/__init__.py
@@ -1,1 +1,2 @@
 from data_trust_logger.utilities.secure_requests import get_access_token, read_token, secure_get
+from data_trust_logger.utilities.basic_logger import basic_logger

--- a/data_trust_logger/utilities/basic_logger.py
+++ b/data_trust_logger/utilities/basic_logger.py
@@ -2,11 +2,9 @@ import logging
 
 
 basic_logger = logging.getLogger("basic_logger")
-basic_logger.setLevel(logging.DEBUG)
 
 handler = logging.StreamHandler()
 handler.setLevel(logging.DEBUG)
-
 formatter = logging.Formatter(fmt='[%(asctime)s] [%(levelname)s] %(message)s', datefmt="%a, %d %b %Y %H:%M:%S")
 handler.setFormatter(formatter)
 

--- a/data_trust_logger/utilities/basic_logger.py
+++ b/data_trust_logger/utilities/basic_logger.py
@@ -1,8 +1,13 @@
 import logging
 
-logging.basicConfig(
-    level=logging.INFO, 
-    format='[%(asctime)s] [%(levelname)s] %(message)s', 
-    datefmt="%a, %d %b %Y %H:%M:%S")
 
-basic_logger = logging.getLogger(__name__)
+basic_logger = logging.getLogger("basic_logger")
+basic_logger.setLevel(logging.DEBUG)
+
+handler = logging.StreamHandler()
+handler.setLevel(logging.DEBUG)
+
+formatter = logging.Formatter(fmt='[%(asctime)s] [%(levelname)s] %(message)s', datefmt="%a, %d %b %Y %H:%M:%S")
+handler.setFormatter(formatter)
+
+basic_logger.addHandler(handler)

--- a/data_trust_logger/utilities/basic_logger.py
+++ b/data_trust_logger/utilities/basic_logger.py
@@ -1,0 +1,8 @@
+import logging
+
+logging.basicConfig(
+    level=logging.INFO, 
+    format='[%(asctime)s] [%(levelname)s] %(message)s', 
+    datefmt="%a, %d %b %Y %H:%M:%S")
+
+basic_logger = logging.getLogger(__name__)

--- a/tests/test_health_metrics_collector.py
+++ b/tests/test_health_metrics_collector.py
@@ -70,7 +70,7 @@ def test_get_data_resources_count(mocker):
     for count in record_counts:
         assert count == seeded_count
 
-def test_get_mci_count_fail():
+def test_get_data_resources_count_fail():
     collector = instantiate_data_resources_collector()
     metrics = collector.collect_metrics()
 
@@ -79,7 +79,7 @@ def test_get_mci_count_fail():
     for count in record_counts:
         assert count == -1
 
-def test_get_mci_statuses(client):
+def test_get_data_resources_statuses(client):
     with requests_mock.Mocker() as m:
         matcher = re.compile('/programs')
         m.get(matcher, json={}, status_code=200)

--- a/tests/test_secure_requests.py
+++ b/tests/test_secure_requests.py
@@ -1,0 +1,18 @@
+import re
+from unittest.mock import mock_open
+import requests_mock
+from expects import be, equal, expect, have_key, have_len
+
+from data_trust_logger.health_audit.mci_collector import instantiate_mci_collector
+
+
+def test_get_statuses_with_invalid_token(client, mocker):
+    """
+    Test that endpoints return a 401 status code when `/tmp/token.txt` does not contain a valid token.
+    """
+    mocker.patch('data_trust_logger.utilities.secure_requests.open', mock_open(read_data='invalid token'))
+    collector = instantiate_mci_collector()
+    metrics = collector.collect_metrics()
+
+    for entry in metrics:
+        expect(entry['endpoint_health']).to(equal(401))

--- a/tests/test_secure_requests.py
+++ b/tests/test_secure_requests.py
@@ -1,9 +1,10 @@
 import re
 from unittest.mock import mock_open
-import requests_mock
+
 from expects import be, equal, expect, have_key, have_len
 
-from data_trust_logger.health_audit.mci_collector import instantiate_mci_collector
+from data_trust_logger.health_audit.mci_collector import \
+    instantiate_mci_collector
 
 
 def test_get_statuses_with_invalid_token(client, mocker):


### PR DESCRIPTION
# Overview 
This PR handles the following Clubhouse cards:
* https://app.clubhouse.io/brighthive/story/470/more-robust-error-handling-logging-in-get-access-token
* https://app.clubhouse.io/brighthive/story/469/re-use-auth-access-token-across-executions-of-health-audit-runner-py
* https://app.clubhouse.io/brighthive/story/471/close-engine-connections

## Getting and using tokens
With this PR, the process for getting a token and hitting a secure endpoint unfolds like so:
1. Request a token
2. Store the token in a `tmp` file
3. If the token cannot be requested, then store an "invalid token" in the `tmp` file
4. Read the token from the `tmp` file, and use it to GET the MCI and DR APIs

## Handling database connections
This PR also insures that the metrics collector properly closes database connections. This includes two major changes:

1. Instantiate the database engine ONCE, i.e., at the beginning of the `audit` function. This differs from the original solution, which instantiate an engine every time the script executed. 

> The typical usage of create_engine() is once per particular database URL, held globally for the lifetime of a single application process....the Engine is most efficient when created just once at the module level of an application, not per-object or per-function call. (SQLAlchemy Docs)
2. Explicitly open a data base connection and close it after running a query:
https://github.com/brighthive/data-trust-logger/blob/ca5b3d5225404dcf8d3522233dd9b551944dc1c5/data_trust_logger/health_audit/metrics_collector.py#L28-L31
